### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/app/configs/prisma/schema.prisma
+++ b/app/configs/prisma/schema.prisma
@@ -2,7 +2,6 @@ datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
     directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 generator client {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.